### PR TITLE
improve finding wireless hardware

### DIFF
--- a/usr/bin/occi
+++ b/usr/bin/occi
@@ -211,7 +211,7 @@ sub handle_wifi {
 
   diag('Configuring network :: ' . $config{wifi_ssid});
 
-  my ($ifconfig) = capture_string('ifconfig', '-s');
+  my ($ifconfig) = capture_string('ifconfig', '-a');
   if ($ifconfig !~ /wlan/) {
     diag('No wireless hardware found.');
   } elsif (defined $config{wifi_password}) {
@@ -348,7 +348,7 @@ sub get_file {
 
   local $/ = undef;
   open my $fh, '<', $path
-    or die "Failed opening $path: $!"; 
+    or die "Failed opening $path: $!";
   my $contents = <$fh>;
   close $fh;
 
@@ -375,7 +375,7 @@ sub put_file {
   }
 
   open my $fh, '>', $path
-    or die "Failed opening $path: $!"; 
+    or die "Failed opening $path: $!";
   print $fh $content;
   close $fh;
 }


### PR DESCRIPTION
Thank you for this tiny little helper. I have a little improvement for
it finding the wireless hardware more reliable.

In my case my Edimax USB WiFi dongle didn't showed up calling `ifconfig -s`

```
$ ifconfig -s
Iface   MTU Met   RX-OK RX-ERR RX-DRP RX-OVR    TX-OK TX-ERR TX-DRP TX-OVR Flg
eth0       1500 0       641      0      0 0           204      0      0      0 BMRU
lo        65536 0         8      0      0 0             8      0      0      0 LRU
``

But with `ifconfig -a` the device was shown and then `occi` activated the WiFi config correctly.